### PR TITLE
Removed Euroduplex from KRM

### DIFF
--- a/Train.json
+++ b/Train.json
@@ -237,7 +237,7 @@
 			"reliability": 1,
 			"cost": 5600000,
 			"operationCosts": 70,
-			"equipments": ["ETCS", "FR", "TVM", "CH", "LU", "ES", "DE", "MA", "KRM"],
+			"equipments": ["ETCS", "FR", "TVM", "CH", "LU", "ES", "DE", "MA"],
 			"maxConnectedUnits": 2,
 			"compatibleWith": [4403, 4501],
 			"exchangeTime": 150,


### PR DESCRIPTION
as per https://github.com/marhei/TrainCompany-Data/issues/795